### PR TITLE
scratchData _needs_ to be 32-bit aligned (ALIGN4)

### DIFF
--- a/fftutil.c
+++ b/fftutil.c
@@ -16,7 +16,7 @@
    * @return none.
  */
 
-static q15_t scratchData[ZERO_FFT_MAX];
+static q15_t ALIGN4 scratchData[ZERO_FFT_MAX];
 
 void arm_bitreversal_q15(
   q15_t * pSrc16,


### PR DESCRIPTION

If scratchData isn't 32-bit aligned, the system will hang when trying to do a 32-bit load/store that isn't aligned.

Add ALIGN4 to force scratchData to be 32-bit aligned.