### PR TITLE
Add feature to disable/enable hanning window

### DIFF
--- a/Adafruit_ZeroFFT.h
+++ b/Adafruit_ZeroFFT.h
@@ -19,6 +19,9 @@
 #define ADAFRUIT_ZEROFFT_ADAFRUIT_ZEROFFT_H_
 
 #include <Arduino.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
 
 #define FFT_BIN(num, fs, size) (num*((float)fs/(float)size)) ///< return the center frequency of FFT bin 'num' based on the sample rate and FFT stize
 #define FFT_INDEX(freq, fs, size) ((int)((float)freq/((float)fs/(float)size))) ///< return the bin index where the specified frequency 'freq' can be found based on the passed sample rate and FFT size
@@ -51,10 +54,32 @@ extern "C"{
     @param source the data to FFT
     @param length the length of the data. This must be a power of 2 and less than or equal to ZERO_FFT_MAX
     @return 0 on success, -1 on failure
-    @note The FFT is run in place on the data. A hanning window is applied to the input data. The complex portion is discarded, and the real values are returned.
+    @note The FFT is run in place on the data. By default, a hanning window is applied to the input data.
+          It can be disabled or enabled using disableFFTWindow and enableFFTWindow functions.
+          The complex portion is discarded, and the real values are returned.
 */
 /**************************************************************************/
 extern int ZeroFFT(q15_t *source, uint16_t length);
+
+/**************************************************************************/
+/*!
+    @brief  enable the hanning window applied to the input signal when running the FFT
+    @param  none
+    @return none
+    @note   Window is enabled by default.
+*/
+/**************************************************************************/
+extern void enableFFTWindow(void);
+
+/**************************************************************************/
+/*!
+    @brief  disable the hanning window applied to the input signal when running the FFT
+    @param  none
+    @return none
+    @note   Window is enabled by default.
+*/
+/**************************************************************************/
+extern void disableFFTWindow(void);
 
 extern const q15_t window_hanning_16[]; ///< a hanning window of length 16
 extern const q15_t window_hanning_32[]; ///< a hanning window of length 32

--- a/examples/CircuitPlayground/CircuitPlayground.ino
+++ b/examples/CircuitPlayground/CircuitPlayground.ino
@@ -1,5 +1,5 @@
 /* This example shows how to use the FFT library with a circuit playground express.
- *  
+ *
  *  The LEDs will map around the circle when frequencies between FREQ_MIN and FREQ_MAX are detected
  */
 
@@ -49,10 +49,10 @@ void loop() {
     *ptr -= avg;
     *ptr++ = *ptr*SCALE_FACTOR;
   }
-  
+
   //run the FFT
   ZeroFFT(inputData, DATA_SIZE);
-  
+
   //set all to 0
   memset(pixelData, 0, NUM_PIXELS*sizeof(int16_t));
 
@@ -75,14 +75,14 @@ void loop() {
 uint32_t Wheel(byte WheelPos) {
   if(WheelPos < 20) {
     return CircuitPlayground.strip.Color(0, 0, 0);
-  } 
+  }
   else if(WheelPos < 85) {
     return CircuitPlayground.strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
-  } 
+  }
   else if(WheelPos < 170) {
     WheelPos -= 85;
     return CircuitPlayground.strip.Color(255 - WheelPos * 3, 0, WheelPos * 3);
-  } 
+  }
   else {
     WheelPos -= 170;
     return CircuitPlayground.strip.Color(0, WheelPos * 3, 255 - WheelPos * 3);

--- a/examples/fft_test/fft_test.ino
+++ b/examples/fft_test/fft_test.ino
@@ -1,9 +1,9 @@
 /* This example shows the most basic usage of the Adafruit ZeroFFT library.
  * it calculates the FFT and prints out the results along with their corresponding frequency
- * 
+ *
  * The signal.h file constains a 200hz sine wave mixed with a weaker 800hz sine wave.
  * The signal was generated at a sample rate of 8000hz.
- * 
+ *
  * Note that you can print only the value (coment out the other two print statements) and use
  * the serial plotter tool to see a graph.
  */
@@ -28,7 +28,7 @@ void setup() {
 
   //data is only meaningful up to sample rate/2, discard the other half
   for(int i=0; i<DATA_SIZE/2; i++){
-    
+
     //print the frequency
     Serial.print(FFT_BIN(i, FS, DATA_SIZE));
     Serial.print(" Hz: ");

--- a/examples/mic_tft/mic_tft.ino
+++ b/examples/mic_tft/mic_tft.ino
@@ -16,7 +16,7 @@
 #define FFT_MAX 512
 #endif
 
-/*set this to a power of 2. 
+/*set this to a power of 2.
  * Lower = faster, lower resolution
  * Higher = slower, higher resolution
   */
@@ -51,7 +51,7 @@ void setup() {
   digitalWrite(A0, HIGH);
   pinMode(A1, OUTPUT);
   digitalWrite(A1, LOW);
-  
+
   tft.begin();
   tft.setRotation(1);
 }
@@ -66,7 +66,7 @@ void drawReference(){
     uint16_t xpos = map(i, 0, DATA_SIZE/2, 0, GRAPH_WIDTH);
     tft.setCursor(xpos, 0);
     tft.drawLine(xpos, GRAPH_MIN, xpos, GRAPH_MAX, ILI9341_RED);
-    
+
     tft.print(fc);
   }
 }
@@ -82,7 +82,7 @@ void loop() {
   //remove DC offset and gain up to 16 bits
   avg = avg/DATA_SIZE;
   for(int i=0; i<DATA_SIZE; i++) data[i] = (data[i] - avg) * 64;
-    
+
   //run the FFT
   ZeroFFT(data, DATA_SIZE);
 
@@ -105,13 +105,13 @@ void loop() {
   thisy = GRAPH_MIN;
   for(int i=1; i<GRAPH_WIDTH; i++){
     uint16_t ix = map(i, 0, GRAPH_WIDTH, 0, DATA_SIZE/2);
-    
+
 #if AUTOSCALE
     thisy = constrain(map(data[ix], 0, GRAPH_HEIGHT, GRAPH_MIN, GRAPH_MAX), GRAPH_OFFSET, GRAPH_MIN);
 #else
     thisy = constrain(map(data[ix], 0, FFT_MAX, GRAPH_MIN, GRAPH_MAX), GRAPH_OFFSET, GRAPH_MIN);
 #endif
- 
+
     tft.drawLine(i - 1, lasty, i, thisy, ILI9341_GREEN);
     lasty = thisy;
   }

--- a/examples/normalized/normalized.ino
+++ b/examples/normalized/normalized.ino
@@ -1,5 +1,5 @@
 /* This example shows how to calculate an FFT an normalize it.
- * 
+ *
  * The signal.h file constains a 200hz sine wave mixed with a weaker 800hz sine wave.
  * The signal was generated at a sample rate of 8000hz.
  */
@@ -35,7 +35,7 @@ void setup() {
     normalized[i] = (float)signal[i] / maxVal;
 
   for(int i=0; i<DATA_SIZE/2; i++){
-    
+
     //print the frequency
     Serial.print(FFT_BIN(i, FS, DATA_SIZE));
     Serial.print(" Hz: ");

--- a/examples/pdm_tft/pdm_tft.ino
+++ b/examples/pdm_tft/pdm_tft.ino
@@ -20,7 +20,7 @@
 #define FFT_MAX 512
 #endif
 
-/*set this to a power of 2. 
+/*set this to a power of 2.
  * Lower = faster, lower resolution
  * Higher = slower, higher resolution
   */
@@ -37,7 +37,7 @@
 #define GRAPH_MAX (tft.height() - GRAPH_HEIGHT)
 static float xScale;
 
-Adafruit_ZeroPDM pdm = Adafruit_ZeroPDM(1, 4); 
+Adafruit_ZeroPDM pdm = Adafruit_ZeroPDM(1, 4);
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 
 int16_t data[DATA_SIZE];
@@ -67,7 +67,7 @@ void setup() {
     while (1);
   }
   Serial.println("PDM configured");
-  
+
   tft.begin();
   tft.setRotation(1);
 }
@@ -82,7 +82,7 @@ void drawReference(){
     uint16_t xpos = map(i, 0, DATA_SIZE/2, 0, GRAPH_WIDTH);
     tft.setCursor(xpos, 0);
     tft.drawLine(xpos, GRAPH_MIN, xpos, GRAPH_MAX, ILI9341_RED);
-    
+
     tft.print(fc);
   }
 }
@@ -92,13 +92,13 @@ void loop() {
   for(int i=0; i<DATA_SIZE; i++){
     uint16_t runningsum = 0;
     uint16_t *sinc_ptr = sincfilter;
-    
+
     for (uint8_t samplenum=0; samplenum < (DECIMATION/16) ; samplenum++) {
        uint16_t sample = pdm.read() & 0xFFFF;    // we read 16 bits at a time, by default the low half
-    
-       ADAPDM_REPEAT_LOOP_16(      // manually unroll loop: for (int8_t b=0; b<16; b++) 
+
+       ADAPDM_REPEAT_LOOP_16(      // manually unroll loop: for (int8_t b=0; b<16; b++)
          {
-           // start at the LSB which is the 'first' bit to come down the line, chronologically 
+           // start at the LSB which is the 'first' bit to come down the line, chronologically
            // (Note we had to set I2S_SERCTRL_BITREV to get this to work, but saves us time!)
            if (sample & 0x1) {
              runningsum += *sinc_ptr;     // do the convolution
@@ -116,7 +116,7 @@ void loop() {
   //remove DC offset
   avg = avg/DATA_SIZE;
   for(int i=0; i<DATA_SIZE; i++) data[i] = (data[i] - avg);
-    
+
   //run the FFT
   ZeroFFT(data, DATA_SIZE);
 
@@ -139,13 +139,13 @@ void loop() {
   thisy = GRAPH_MIN;
   for(int i=1; i<GRAPH_WIDTH; i++){
     uint16_t ix = map(i, 0, GRAPH_WIDTH, 0, DATA_SIZE/2);
-    
+
 #if AUTOSCALE
     thisy = constrain(map(data[ix], 0, GRAPH_HEIGHT, GRAPH_MIN, GRAPH_MAX), GRAPH_OFFSET, GRAPH_MIN);
 #else
     thisy = constrain(map(data[ix], 0, FFT_MAX, GRAPH_MIN, GRAPH_MAX), GRAPH_OFFSET, GRAPH_MIN);
 #endif
- 
+
     tft.drawLine(i - 1, lasty, i, thisy, ILI9341_GREEN);
     lasty = thisy;
   }

--- a/examples/pdm_tft_fancy/pdm_tft_fancy.ino
+++ b/examples/pdm_tft_fancy/pdm_tft_fancy.ino
@@ -13,7 +13,7 @@
 #define TFT_DC   10
 #define SD_CS    5
 
-/*set this to a power of 2. 
+/*set this to a power of 2.
  * Lower = faster, lower resolution
  * Higher = slower, higher resolution
   */
@@ -30,7 +30,7 @@
 #define GRAPH_MAX (tft.height() - GRAPH_HEIGHT)
 static float xScale;
 
-Adafruit_ZeroPDM pdm = Adafruit_ZeroPDM(1, 4); 
+Adafruit_ZeroPDM pdm = Adafruit_ZeroPDM(1, 4);
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 
 int16_t data[DATA_SIZE];
@@ -79,7 +79,7 @@ void setup() {
     while (1);
   }
   Serial.println("PDM configured");
-  
+
   tft.begin();
   tft.setRotation(1);
 
@@ -94,13 +94,13 @@ void loop() {
   for(int i=0; i<DATA_SIZE; i++){
     uint16_t runningsum = 0;
     uint16_t *sinc_ptr = sincfilter;
-    
+
     for (uint8_t samplenum=0; samplenum < (DECIMATION/16) ; samplenum++) {
        uint16_t sample = pdm.read() & 0xFFFF;    // we read 16 bits at a time, by default the low half
-    
-       ADAPDM_REPEAT_LOOP_16(      // manually unroll loop: for (int8_t b=0; b<16; b++) 
+
+       ADAPDM_REPEAT_LOOP_16(      // manually unroll loop: for (int8_t b=0; b<16; b++)
          {
-           // start at the LSB which is the 'first' bit to come down the line, chronologically 
+           // start at the LSB which is the 'first' bit to come down the line, chronologically
            // (Note we had to set I2S_SERCTRL_BITREV to get this to work, but saves us time!)
            if (sample & 0x1) {
              runningsum += *sinc_ptr;     // do the convolution
@@ -118,7 +118,7 @@ void loop() {
   //remove DC offset
   avg = avg/DATA_SIZE;
   for(int i=0; i<DATA_SIZE; i++) data[i] = (data[i] - avg);
-    
+
   //run the FFT
   ZeroFFT(data, DATA_SIZE);
 
@@ -134,14 +134,14 @@ void loop() {
 
     if(i > 3)
       data[i] = (data[i] + data[i-1] + data[i-2] + data[i - 3]) / 4;
-      
+
     else data[i] = 0;
   }
 
   //normalize again
   maxVal = 0;
   for(int i=0; i<DATA_SIZE/2; i++) if(data[i] > maxVal) maxVal = data[i];
-  
+
   for(int i=0; i<DATA_SIZE/2; i++)
     data[i] =(float)data[i] / maxVal * GRAPH_HEIGHT;
 
@@ -158,9 +158,9 @@ void loop() {
   thisy = GRAPH_MIN;
   for(int i=1; i<GRAPH_WIDTH; i++){
     uint16_t ix = map(i, 0, GRAPH_WIDTH, 0, DATA_SIZE/2);
-    
+
     thisy = constrain(map(data[ix], 0, GRAPH_HEIGHT, GRAPH_MIN, GRAPH_MAX), GRAPH_OFFSET, GRAPH_MIN);
- 
+
     tft.drawLine(i - 1, lasty, i, thisy, ILI9341_GREEN);
     lasty = thisy;
 

--- a/fftutil.c
+++ b/fftutil.c
@@ -17,6 +17,7 @@
  */
 
 static q15_t ALIGN4 scratchData[ZERO_FFT_MAX];
+static bool useWindow = true;
 
 void arm_bitreversal_q15(
   q15_t * pSrc16,
@@ -187,10 +188,22 @@ void arm_radix2_butterfly_q15(
 
 static inline void applyWindow(q15_t *src, const q15_t *window, uint16_t len)
 {
-	while(len--){
-		int32_t val = *src * *window++;
-		*src++ = val >> 15;
-	}
+    if (useWindow == true) {
+    	while(len--) {
+    		int32_t val = *src * *window++;
+    		*src++ = val >> 15;
+    	}
+    }
+}
+
+void enableFFTWindow(void)
+{
+    useWindow = true;
+}
+
+void disableFFTWindow(void)
+{
+    useWindow = false;
 }
 
 int ZeroFFT(q15_t *source, uint16_t length)
@@ -215,7 +228,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    /*  Initialise the bit reversal table pointer */
 	    pBitRevTable = (uint16_t *) armBitRevTable;
 
-	    applyWindow(source, window_hanning_4096, 4096);
+       applyWindow(source, window_hanning_4096, 4096);
 
 	    break;
 #endif
@@ -232,7 +245,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    /*  Initialise the bit reversal table pointer */
 	    pBitRevTable = (uint16_t *) & armBitRevTable[1];
 
-	    applyWindow(source, window_hanning_2048, 2048);
+       applyWindow(source, window_hanning_2048, 2048);
 
 	    break;
 
@@ -245,7 +258,8 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 4u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[3];
 
-	    applyWindow(source, window_hanning_1024, 1024);
+       applyWindow(source, window_hanning_1024, 1024);
+
 	    break;
 #endif
 
@@ -256,7 +270,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 8u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[7];
 
-	    applyWindow(source, window_hanning_512, 512);
+       applyWindow(source, window_hanning_512, 512);
 
 	    break;
 #endif
@@ -268,7 +282,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 16u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[15];
 
-	    applyWindow(source, window_hanning_256, 256);
+        applyWindow(source, window_hanning_256, 256);
 
 	    break;
 #endif
@@ -279,7 +293,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 32u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[31];
 
-	    applyWindow(source, window_hanning_128, 128);
+        applyWindow(source, window_hanning_128, 128);
 
 	    break;
 
@@ -289,7 +303,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 64u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[63];
 
-	    applyWindow(source, window_hanning_64, 64);
+        applyWindow(source, window_hanning_64, 64);
 
 	    break;
 
@@ -299,7 +313,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 128u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[127];
 
-	    applyWindow(source, window_hanning_32, 32);
+        applyWindow(source, window_hanning_32, 32);
 
 	    break;
 
@@ -309,7 +323,7 @@ int ZeroFFT(q15_t *source, uint16_t length)
 	    bitRevFactor = 256u;
 	    pBitRevTable = (uint16_t *) & armBitRevTable[255];
 
-	    applyWindow(source, window_hanning_16, 16);
+        applyWindow(source, window_hanning_16, 16);
 
 	    break;
 


### PR DESCRIPTION
The hanning window function is useful when there is  a chance of leakage in the FFT results for some scenarios with periodic signals. However, windows aren't always the best approach and not using them can result in a better distribution of the FFT results. Therefore the functions enableFFTWindow() and disableFFTWindow were added. By default, hanning window is enabled so the library keeps full compatibility and can be updated without any change.
Additional includes were added to the Adafruit_ZeroFFT.h header file so it can be used with little modification with a project outside Arduino evironment just by commenting out #include <Arduino.h>.