### PR TITLE
Return FFT's magnitude

### DIFF
--- a/fftutil.c
+++ b/fftutil.c
@@ -331,11 +331,13 @@ int ZeroFFT(q15_t *source, uint16_t length)
 
 	pSrc = source;
 	pOut = scratchData;
+	uint16_t alphaMax, betaMin;  // Use Alpha Max plus Beta Min to quickly approximate magnitude
 	for(int i=0; i<length; i++){
-		  q15_t val = *pOut++;
-		  uint32_t v = abs(val);
-		  *pSrc++ = v;
-		  pOut++; //discard imaginary phase val
+		  q15_t real = *pOut++;
+		  q15_t imag = *pOut++;
+		  alphaMax = abs(real > imag ? real : imag);
+		  betaMin = abs(real < imag ? real : imag)/4;
+		  *pSrc++ = (uint32_t)(alphaMax + betaMin);
 	  }
 
 	return 0;


### PR DESCRIPTION
This changes the output of the function to return the value users
would expect from an FFT, it's magnitude.

The previous behavior was to discard the imaginary data, which can
cause the output to vary sinusoidally over time. Returning the
magnitude of the real and imaginary vector produces a consistent result.

Calculating the magnitude with multiplications and square roots can
be computationally expensive. It can slow the function down by 4x
for a 1024 length input. This approach uses the alpha max plus beta
min algorithm (https://en.wikipedia.org/wiki/Alpha_max_plus_beta_min_algorithm)
to efficiently return the magnitude. Using this method produced no
measurable differences in the function's runtime.